### PR TITLE
Border delete, deleteHistoryElement fix 

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/example/qrcodescanner/ui/Pages/History.kt
+++ b/app/src/main/java/com/example/qrcodescanner/ui/Pages/History.kt
@@ -108,6 +108,7 @@ fun DeleteHistoryElement(modifier: Modifier = Modifier) {
         )
     }
 }
+
 @Composable
 fun HistoryElement(qrCode: String, modifier: Modifier = Modifier) {
     var isExpanded by rememberSaveable {

--- a/app/src/main/java/com/example/qrcodescanner/ui/Pages/MainPage.kt
+++ b/app/src/main/java/com/example/qrcodescanner/ui/Pages/MainPage.kt
@@ -1,5 +1,7 @@
 package com.example.qrcodescanner.ui.Pages
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -7,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.qrcodescanner.ui.components.CameraHandler
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun MainPage() {
     Column(modifier = Modifier.fillMaxSize()) {
@@ -19,6 +22,7 @@ fun MainPage() {
 }
 
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview
 @Composable
 fun MainPagePreview() {

--- a/app/src/main/java/com/example/qrcodescanner/ui/components/CameraController.kt
+++ b/app/src/main/java/com/example/qrcodescanner/ui/components/CameraController.kt
@@ -114,7 +114,6 @@ fun CameraController(modifier: Modifier = Modifier, onQRCodeScanned: (String) ->
                 previewView
             },
         )
-        DrawRectangle(rect = boundingRect)
     }
 }
 
@@ -149,20 +148,5 @@ fun CameraHandler(modifier: Modifier = Modifier) {
                 permissionsRequest.launch(Manifest.permission.CAMERA)
             }, openDialog = openDialog
         )
-    }
-}
-
-@Composable
-fun DrawRectangle(rect: Rect?) {
-    val composeRect = rect?.toComposeRect()
-    composeRect?.let {
-        Canvas(modifier = Modifier.fillMaxSize()) {
-            drawRect(
-                color = Color.Red,
-                topLeft = Offset(it.left, it.top),
-                size = Size(it.width, it.height),
-                style = Stroke(width = 5f)
-            )
-        }
     }
 }

--- a/app/src/main/java/com/example/qrcodescanner/utils/QRStorage.kt
+++ b/app/src/main/java/com/example/qrcodescanner/utils/QRStorage.kt
@@ -7,7 +7,9 @@ import com.example.qrcodescanner.data.storage.dataStore
 
 //Deleting the history of QR codes
 suspend fun deleteHistory(context: Context) {
-    context.dataStore.edit { it.clear() }
+    context.dataStore.edit { preferences ->
+        preferences.remove(PreferencesKeys.QR_CODES)
+    }
 }
 
 object PreferencesKeys {


### PR DESCRIPTION
There's no longer border around QR code

deleteHistoryElement no longer deletes whole settings, now it deletes only the history of QR codes (earlier - deleted theme settings)